### PR TITLE
build: :heavy_plus_sign: add `checkmate` to `DESCRIPTION` imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Depends:
     tidyverse
 Imports:
     arrow,
+    checkmate,
     cli,
     data.table,
     DBI,


### PR DESCRIPTION
## Description

This PR adds the `checkmate` package to the "Imports" section of the `DESCRIPTION` file. The tests failed in just recipe because this package was missing.

This PR needs no review.
