### PR TITLE
chore: :fire: remove `randomly_sample()` from pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -21,4 +21,3 @@ reference:
   - starts_with("load")
   - starts_with("path")
   - starts_with("read")
-  - randomly_sample


### PR DESCRIPTION
# Description

Since the function was removed in #32.

Needs no review.