### PR TITLE
ci: :bug: forgot explicit reference to branch in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
 
 
   pkgdown:
-    uses: dp-next/.github/.github/workflows/reusable-pkgdown.yml
+    uses: dp-next/.github/.github/workflows/reusable-pkgdown.yml@main
     needs: cran-checks
     permissions:
       contents: write


### PR DESCRIPTION
## Description

Needs the explicit `@main`.

No review needed.