### PR TITLE
build: :pushpin: add that we use `R>=4.1.0`, since we e.g., use the new(er)  pipe `|>

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R:
 Description: Imports, prepares, and saves the original SAS data files into
     the Parquet format.
 License: MIT + file LICENSE
-Depends: 
+Depends:
     R (>= 4.1.0)
 Imports:
     arrow,


### PR DESCRIPTION
# Description

This was noted in the CMD check but not as an "official" note.

Needs no review.

## Checklist

- [X] Ran `just run-all`
