### PR TITLE
docs: :memo: update index page with overview, purpose, and why parquet sections

### DIFF
--- a/vignettes/index.qmd
+++ b/vignettes/index.qmd
@@ -25,7 +25,7 @@ For an introduction to using the package, please see the guides.
 ## Purpose
 
 The primary purpose of the `registers2parquet` package is to
-simplify the process of converting the large Danish registers into 
+simplify the process of converting the large Danish registers into
 the more modern Parquet storage format as well as to simplify reading
 these Parquet files.
 


### PR DESCRIPTION
# Description

This PR updates and adds sections to the index page, including an overview with link to the design vignette, a purpose section, and a section on why it makes sense to convert to Parquet files. 

This last section could potentially link to another page with more elaboration, context, and examples of the advantages in the future (so this index page doesn't get too much in-depth information). The section was largely made with autocomplete/co-pilot and is just meant as an initial version. I suspect you, @lwjohnst86, will have more/other perspectives to add to that section.

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
- [X] If docs were added, Markdown is formatted
