### PR TITLE
docs: :memo: add white backgrounds to subgraphs in `flow.mmd`

### DIFF
--- a/vignettes/flow.mmd
+++ b/vignettes/flow.mmd
@@ -35,3 +35,7 @@ flowchart LR
     A6 -->|import &<br>join| F5
     F5 -->|export| B5
     A7 -->|import| F6 -->|export| B6
+
+    %% Styling
+    style SAS fill:#FFFFFF, color:#000000
+    style Parquet fill:#FFFFFF, color:#000000


### PR DESCRIPTION
# Description

So they aren't a dark grey that's difficult to read the text on.

Needs to review. 

## Checklist

- [X] Ran `just run-all`
