### PR TITLE
test: :white_check_mark: fix test by changing `expect_identical()` to `expect_match()`

### DIFF
--- a/tests/testthat/test-list-files.R
+++ b/tests/testthat/test-list-files.R
@@ -31,7 +31,7 @@ test_that("file name gets converted as a directory instead", {
   actual <- fs::file_temp(pattern = "database", ext = ".sas7bdat") |>
     path_alter_filename_as_dir()
 
-  expect_identical(fs::path_file(actual), "database")
+  expect_match(fs::path_file(actual), "database")
 })
 
 test_that("path is converted to a Parquet Partition in another directory", {


### PR DESCRIPTION
# Description

It seems that `fs::file_temp()` creates files with names that start with the given pattern but adds some random characters aftwards, e.g., "database69252c5c6d7a.sas7bdat". So, changing the test to expect a match of "database" instead of the filename being identical makes the test pass.

Needs no review.

## Checklist

- [X] Ran `just run-all`
