### PR TITLE
refactor: :adhesive_bandage: ensure `source_file` is character before Arrow schema creation

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -83,7 +83,7 @@ convert_file_in_chunks <- function(path, output_path, chunk_size = 10000000L) {
   # Read first chunk to establish schema.
   chunk <- haven::read_sas(path, skip = skip, n_max = chunk_size) |>
     column_names_to_lower() |>
-    dplyr::mutate(source_file = path)
+    dplyr::mutate(source_file = as.character(path))
   schema <- create_arrow_schema(chunk)
 
   repeat {
@@ -106,7 +106,7 @@ convert_file_in_chunks <- function(path, output_path, chunk_size = 10000000L) {
 
     chunk <- haven::read_sas(path, skip = skip, n_max = chunk_size) |>
       column_names_to_lower() |>
-      dplyr::mutate(source_file = path)
+      dplyr::mutate(source_file = as.character(path))
   }
 
   invisible(partition_path)


### PR DESCRIPTION
# Description

Otherwise, if a `fs::path` is passed in `paths` in `convert_to_parquet()`, the `create_arrow_schema()` won't know how to handle that. 

When `paths` is `fs::path`, the class is also a `character`, which is why it passes the initial tests in `convert_*()`. 
Alternatively, I could handle it in the `create_arrow_schema()` function?

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
