### PR TITLE
ci: :construction_worker: comment out `macos-latest` in `build`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
+          # Commented out bc there seems to be issues with the macos build currently.
+          # - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           # NOTE: These take a long time to run, so won't use them for regular development.


### PR DESCRIPTION
# Description

There seems to be issues with it currently which we can't fix, so we'll remove it for now.

Needs no review.