### PR TITLE
chore: :technologist: add `list-todos` just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -81,3 +81,7 @@ lint:
 preview-website:
   #!/usr/bin/env Rscript
   pkgdown::preview_site()
+
+# List all TODO items in the repository
+list-todos:
+  grep -R -n --exclude="justfile" --exclude-dir="docs/deps" "TODO" *


### PR DESCRIPTION
# Description

To make it easier to get an overview of TODOs in the repo. 

Needs no review.