### PR TITLE
refactor: :recycle: parameter name to simply `path`

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -6,22 +6,21 @@
 #' register, e.g., different years of the same register.
 #'
 #' The function looks for a year (the first four consecutive digits) in the file
-#' names in `file_paths` to use the year as partition, see `vignettes("design")`
+#' names in `path` to use the year as partition, see `vignettes("design")`
 #' for more information about the partitioning.
 #'
 #' If a year is found, the data is saved as a partition by year in the output
-#' directory, e.g., `path/to/register_name/year=2020/part-ad5b.parquet` (the
-#' ending being an UUID). If no year is found in the file name, the data is
-#' saved in a `year=__HIVE_DEFAULT_PARTITION__` partition, which is the
-#' standard Hive convention for missing partition values.
+#' directory, e.g., `output_dir/year=2020/part-ad5b.parquet` (the ending being
+#' a UUID). If no year is found in the file name, the data is saved in a
+#' `year=__HIVE_DEFAULT_PARTITION__` partition, which is the standard Hive
+#' convention for missing partition values.
 #'
 #' Because this function only converts one file at a time (in chunks) to be
 #' able to handle larger-than-memory SAS files, duplicate rows across files are
 #' not deduplicated.
 #'
-#' @param file_paths A character vector with the absolute path(s) to a SAS
-#'    file(s) for one register. See [list_sas_files()], which is a helper for
-#'    for this parameter.
+#' @param path A character vector of one or more paths to SAS file(s) for one
+#'    register. See [list_sas_files()], which is a helper for this parameter.
 #' @param output_dir A character scalar with the path to the directory to save
 #'    the output Parquet file to. Should include the register name as the last
 #'    part of the path. E.g., `path/to/register_name/`.
@@ -36,31 +35,31 @@
 #' @examples
 #' sas_file_directory <- fs::path_package("fastreg", "extdata")
 #' convert_to_parquet(
-#'   file_paths = list_sas_files(sas_file_directory),
+#'   path = list_sas_files(sas_file_directory),
 #'   output_dir = fs::path_temp("path/to/register_name/")
 #' )
 convert_to_parquet <- function(
-  file_paths,
+  path,
   output_dir,
   chunk_size = 10000000L
 ) {
   # Initial checks.
-  checkmate::assert_character(file_paths)
-  checkmate::assert_file_exists(file_paths)
-  checkmate::assert_true(is_same_register(file_paths))
+  checkmate::assert_character(path)
+  checkmate::assert_file_exists(path)
+  checkmate::assert_true(is_same_register(path))
   checkmate::assert_character(output_dir)
   checkmate::assert_scalar(output_dir)
   checkmate::assert_int(chunk_size, lower = 10000L)
 
   # Convert files.
   purrr::walk(
-    file_paths,
-    \(file_path) convert_file_in_chunks(file_path, output_dir, chunk_size)
+    path,
+    \(p) convert_file_in_chunks(p, output_dir, chunk_size)
   )
 
   # Success message.
   cli::cli_alert_success(
-    "Successfully converted {.val {fs::path_file(file_paths)}} and saved it in {.path {output_dir}}."
+    "Successfully converted {.val {fs::path_file(path)}} and saved it in {.path {output_dir}}."
   )
 
   invisible(output_dir)
@@ -206,16 +205,16 @@ column_names_to_lower <- function(data) {
 #' Check that all file paths are from the same register
 #'
 #' Checks that all register names (file names without any non-letters) in
-#' `file_paths` are identical, i.e., the registers have the same name.
+#' `path` are identical, i.e., the registers have the same name.
 #'
-#' @param file_paths A character vector with paths to SAS register files.
+#' @param path A character vector of one or more paths to SAS register files.
 #'
-#' @returns A logical that's TRUE if all `file_paths` point to files from the
+#' @returns A logical that's TRUE if all paths point to files from the
 #'  same register, based on the file names.
 #'
 #' @keywords internal
-is_same_register <- function(file_paths) {
-  register_names <- get_register_names(file_paths)
+is_same_register <- function(path) {
+  register_names <- get_register_names(path)
 
   length(unique(register_names)) == 1L
 }

--- a/R/get-helpers.R
+++ b/R/get-helpers.R
@@ -1,15 +1,15 @@
 #' Get the register names from file paths
 #'
-#' Removes all non-letters from the file names in `paths`.
+#' Removes all non-letters from the file names in `path`.
 #'
-#' @param paths Character vector with file paths.
+#' @param path A character vector of one or more file paths.
 #'
-#' @returns The file names from `paths` with only letters (all non-letter
+#' @returns The file names from `path` with only letters (all non-letters
 #'  removed).
 #'
 #' @keywords internal
-get_register_names <- function(paths) {
-  paths |>
+get_register_names <- function(path) {
+  path |>
     fs::path_file() |>
     fs::path_ext_remove() |>
     # Remove everything that's not a letter.
@@ -21,18 +21,18 @@ get_register_names <- function(paths) {
 #' Groups a vector of file paths by their register name, where the register
 #' name is derived from the file name with all non-letter characters removed.
 #'
-#' @param paths A character vector of file paths.
+#' @param path A character vector of one or more file paths.
 #'
 #' @returns A list of character vectors, where each element contains paths
 #'   belonging to the same register.
 #'
 #' @export
 #' @examples
-#' paths <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat", "data/ind2020.sas7bdat")
-#' split_paths_by_register(paths)
-split_paths_by_register <- function(paths) {
-  register_names <- get_register_names(paths)
-  split(paths, register_names) |> unname()
+#' path <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat", "data/ind2020.sas7bdat")
+#' split_paths_by_register(path)
+split_paths_by_register <- function(path) {
+  register_names <- get_register_names(path)
+  split(path, register_names) |> unname()
 }
 
 #' Get register name from a group of file paths
@@ -40,22 +40,21 @@ split_paths_by_register <- function(paths) {
 #' Extracts the register name from the path in a group. Intended for use
 #' with groups created by [split_paths_by_register()] in the targets template.
 #'
-#' @param file_paths A character vector of file file_paths from the same
-#'  register.
+#' @param path A character vector of one or more paths from the same register.
 #'
 #' @returns A character scalar with the register name.
 #'
 #' @export
 #' @examples
-#' file_paths <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat")
-#' get_register_name(file_paths)
-get_register_name <- function(file_paths) {
-  register_name <- unique(get_register_names(file_paths))
+#' path <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat")
+#' get_register_name(path)
+get_register_name <- function(path) {
+  register_name <- unique(get_register_names(path))
 
   if (length(register_name) > 1) {
     cli::cli_abort(c(
       "Multiple register names were found: {.val {register_name}}.",
-      "i" = "Expected a single register name from {.path {file_paths}}."
+      "i" = "Expected a single register name from {.path {path}}."
     ))
   }
 

--- a/man/convert_to_parquet.Rd
+++ b/man/convert_to_parquet.Rd
@@ -4,12 +4,11 @@
 \alias{convert_to_parquet}
 \title{Convert register SAS file(s) and save to Parquet format}
 \usage{
-convert_to_parquet(file_paths, output_dir, chunk_size = 10000000L)
+convert_to_parquet(path, output_dir, chunk_size = 10000000L)
 }
 \arguments{
-\item{file_paths}{A character vector with the absolute path(s) to a SAS
-file(s) for one register. See \code{\link[=list_sas_files]{list_sas_files()}}, which is a helper for
-for this parameter.}
+\item{path}{A character vector of one or more paths to SAS file(s) for one
+register. See \code{\link[=list_sas_files]{list_sas_files()}}, which is a helper for this parameter.}
 
 \item{output_dir}{A character scalar with the path to the directory to save
 the output Parquet file to. Should include the register name as the last
@@ -29,14 +28,14 @@ data in Parquet format. It expects the input SAS files to come from the same
 register, e.g., different years of the same register.
 
 The function looks for a year (the first four consecutive digits) in the file
-names in \code{file_paths} to use the year as partition, see \code{vignettes("design")}
+names in \code{path} to use the year as partition, see \code{vignettes("design")}
 for more information about the partitioning.
 
 If a year is found, the data is saved as a partition by year in the output
-directory, e.g., \code{path/to/register_name/year=2020/part-ad5b.parquet} (the
-ending being an UUID). If no year is found in the file name, the data is
-saved in a \verb{year=__HIVE_DEFAULT_PARTITION__} partition, which is the
-standard Hive convention for missing partition values.
+directory, e.g., \code{output_dir/year=2020/part-ad5b.parquet} (the ending being
+a UUID). If no year is found in the file name, the data is saved in a
+\verb{year=__HIVE_DEFAULT_PARTITION__} partition, which is the standard Hive
+convention for missing partition values.
 
 Because this function only converts one file at a time (in chunks) to be
 able to handle larger-than-memory SAS files, duplicate rows across files are
@@ -45,7 +44,7 @@ not deduplicated.
 \examples{
 sas_file_directory <- fs::path_package("fastreg", "extdata")
 convert_to_parquet(
-  file_paths = list_sas_files(sas_file_directory),
+  path = list_sas_files(sas_file_directory),
   output_dir = fs::path_temp("path/to/register_name/")
 )
 }

--- a/man/get_register_name.Rd
+++ b/man/get_register_name.Rd
@@ -4,11 +4,10 @@
 \alias{get_register_name}
 \title{Get register name from a group of file paths}
 \usage{
-get_register_name(file_paths)
+get_register_name(path)
 }
 \arguments{
-\item{file_paths}{A character vector of file file_paths from the same
-register.}
+\item{path}{A character vector of one or more paths from the same register.}
 }
 \value{
 A character scalar with the register name.
@@ -18,6 +17,6 @@ Extracts the register name from the path in a group. Intended for use
 with groups created by \code{\link[=split_paths_by_register]{split_paths_by_register()}} in the targets template.
 }
 \examples{
-file_paths <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat")
-get_register_name(file_paths)
+path <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat")
+get_register_name(path)
 }

--- a/man/get_register_names.Rd
+++ b/man/get_register_names.Rd
@@ -4,16 +4,16 @@
 \alias{get_register_names}
 \title{Get the register names from file paths}
 \usage{
-get_register_names(paths)
+get_register_names(path)
 }
 \arguments{
-\item{paths}{Character vector with file paths.}
+\item{path}{A character vector of one or more file paths.}
 }
 \value{
-The file names from \code{paths} with only letters (all non-letter
+The file names from \code{path} with only letters (all non-letters
 removed).
 }
 \description{
-Removes all non-letters from the file names in \code{paths}.
+Removes all non-letters from the file names in \code{path}.
 }
 \keyword{internal}

--- a/man/is_same_register.Rd
+++ b/man/is_same_register.Rd
@@ -4,17 +4,17 @@
 \alias{is_same_register}
 \title{Check that all file paths are from the same register}
 \usage{
-is_same_register(file_paths)
+is_same_register(path)
 }
 \arguments{
-\item{file_paths}{A character vector with paths to SAS register files.}
+\item{path}{A character vector of one or more paths to SAS register files.}
 }
 \value{
-A logical that's TRUE if all \code{file_paths} point to files from the
+A logical that's TRUE if all paths point to files from the
 same register, based on the file names.
 }
 \description{
 Checks that all register names (file names without any non-letters) in
-\code{file_paths} are identical, i.e., the registers have the same name.
+\code{path} are identical, i.e., the registers have the same name.
 }
 \keyword{internal}

--- a/man/split_paths_by_register.Rd
+++ b/man/split_paths_by_register.Rd
@@ -4,10 +4,10 @@
 \alias{split_paths_by_register}
 \title{Group file paths by register name}
 \usage{
-split_paths_by_register(paths)
+split_paths_by_register(path)
 }
 \arguments{
-\item{paths}{A character vector of file paths.}
+\item{path}{A character vector of one or more file paths.}
 }
 \value{
 A list of character vectors, where each element contains paths
@@ -18,6 +18,6 @@ Groups a vector of file paths by their register name, where the register
 name is derived from the file name with all non-letter characters removed.
 }
 \examples{
-paths <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat", "data/ind2020.sas7bdat")
-split_paths_by_register(paths)
+path <- c("data/bef2020.sas7bdat", "data/bef2021.sas7bdat", "data/ind2020.sas7bdat")
+split_paths_by_register(path)
 }

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -29,15 +29,15 @@ suppressWarnings(haven::write_sas(co2_df, temp_sas_years[2]))
 
 # Convert SAS to Parquet.
 output_no_years_one_file <- convert_to_parquet(
-  file_paths = temp_sas_no_years[1],
+  path = temp_sas_no_years[1],
   output_dir = temp_output_no_year_one_file
 )
 output_no_years <- convert_to_parquet(
-  file_paths = temp_sas_no_years,
+  path = temp_sas_no_years,
   output_dir = temp_output_no_year
 )
 output_multiple_years <- convert_to_parquet(
-  file_paths = temp_sas_years,
+  path = temp_sas_years,
   output_dir = temp_output_multiple_years
 )
 
@@ -129,23 +129,23 @@ test_that("number of rows are as expected", {
 })
 
 test_that("incorrect parameters generate errors", {
-  # Incorrect file_paths type.
+  # Incorrect path type.
   expect_error(convert_to_parquet(
-    file_paths = 1,
+    path = 1,
     output_dir = temp_output_multiple_years
   ))
   # Incorrect output_dir type.
   expect_error(convert_to_parquet(
-    file_paths = temp_sas_years[[1]],
+    path = temp_sas_years[[1]],
     output_dir = 1
   ))
   expect_error(convert_to_parquet(
-    file_paths = rep(temp_output_multiple_years, times = 2),
+    path = rep(temp_output_multiple_years, times = 2),
     output_dir = temp_sas_years[[1]]
   ))
   # Incorrect chunk size type (lower than allowed).
   expect_error(convert_to_parquet(
-    file_paths = temp_sas_no_years,
+    path = temp_sas_no_years,
     output_dir = temp_output_no_year_one_file,
     chunk_size = 10L
   ))
@@ -153,14 +153,14 @@ test_that("incorrect parameters generate errors", {
   temp_different_register <- fs::path_temp("other_2020.sas7bdat")
   suppressWarnings(haven::write_sas(co2_df, temp_different_register))
   expect_error(convert_to_parquet(
-    file_paths = c(temp_sas_years[[1]], temp_different_register),
+    path = c(temp_sas_years[[1]], temp_different_register),
     output_dir = temp_output_multiple_years,
   ))
 })
 
 test_that("files passed in the paths parameter must exist", {
   expect_error(convert_to_parquet(
-    file_paths = fs::file_temp(),
+    path = fs::file_temp(),
     output_dir = temp_output_multiple_years
   ))
 })
@@ -181,7 +181,7 @@ test_that("parts are named correctly with chunked files", {
   suppressWarnings(haven::write_sas(df, temp_paths[[2]]))
 
   convert_to_parquet(
-    file_paths = temp_paths,
+    path = temp_paths,
     output_dir = output_dir,
     chunk_size = 10000L
   )
@@ -197,7 +197,7 @@ test_that("mixed files with and without years are partitioned correctly", {
   output_dir_mixed <- fs::path_temp("output_mixed")
 
   convert_to_parquet(
-    file_paths = c(temp_sas_no_years[[1]], temp_sas_years[[1]]),
+    path = c(temp_sas_no_years[[1]], temp_sas_years[[1]]),
     output_dir = output_dir_mixed
   )
 
@@ -222,25 +222,25 @@ test_that("larger files are partitioned as expected with chunk_size = 1 million"
   skip_on_cran()
 
   kontakter_list <- helper_create_simulated_kontakter()
-  file_paths <- paste0(names(kontakter_list), ".sas7bdat") |>
+  path <- paste0(names(kontakter_list), ".sas7bdat") |>
     fs::path_temp() |>
     as.character()
   temp_output <- fs::path_temp("kontakter")
 
-  suppressWarnings(haven::write_sas(kontakter_list[[1]], file_paths[[1]]))
-  suppressWarnings(haven::write_sas(kontakter_list[[2]], file_paths[[2]]))
-  suppressWarnings(haven::write_sas(kontakter_list[[3]], file_paths[[3]]))
+  suppressWarnings(haven::write_sas(kontakter_list[[1]], path[[1]]))
+  suppressWarnings(haven::write_sas(kontakter_list[[2]], path[[2]]))
+  suppressWarnings(haven::write_sas(kontakter_list[[3]], path[[3]]))
 
   chunk_size <- 1000000L # Create variable so it can be used to calculate expected number of files.
 
   actual_output_dir <- convert_to_parquet(
-    file_paths = file_paths,
+    path = path,
     output_dir = temp_output,
     chunk_size = chunk_size
   )
 
   # Check number of files per partition.
-  sas_files <- purrr::map(file_paths, haven::read_sas)
+  sas_files <- purrr::map(path, haven::read_sas)
   n_files_expected <- sas_files |>
     purrr::map_int(nrow) /
     chunk_size

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -1,6 +1,6 @@
 # Prepare data to be read.
 kontakter_list <- helper_create_simulated_kontakter(n = 1000)
-file_paths <- paste0(names(kontakter_list), ".sas7bdat") |>
+path <- paste0(names(kontakter_list), ".sas7bdat") |>
   fs::path_temp() |>
   as.character()
 temp_output <- fs::path_temp("kontakter")
@@ -10,12 +10,12 @@ if (fs::dir_exists(temp_output)) {
   fs::dir_delete(temp_output)
 }
 
-suppressWarnings(haven::write_sas(kontakter_list[[1]], file_paths[[1]]))
-suppressWarnings(haven::write_sas(kontakter_list[[2]], file_paths[[2]]))
-suppressWarnings(haven::write_sas(kontakter_list[[3]], file_paths[[3]]))
+suppressWarnings(haven::write_sas(kontakter_list[[1]], path[[1]]))
+suppressWarnings(haven::write_sas(kontakter_list[[2]], path[[2]]))
+suppressWarnings(haven::write_sas(kontakter_list[[3]], path[[3]]))
 
 # Use convert_to_parquet() for conversion
-convert_to_parquet(file_paths = file_paths, output_dir = temp_output)
+convert_to_parquet(path = path, output_dir = temp_output)
 
 test_that("reading a single Parquet file works as expected", {
   # Read single Parquet file (from SAS file without year in filename).
@@ -27,19 +27,19 @@ test_that("reading a single Parquet file works as expected", {
   ))) |>
     dplyr::collect()
 
-  expected <- haven::read_sas(file_paths[[1]])
+  expected <- haven::read_sas(path[[1]])
 
   expect_equal(
     actual |> dplyr::select(-"source_file"),
     expected
   )
-  expect_all_equal(actual$source_file, file_paths[[1]])
+  expect_all_equal(actual$source_file, path[[1]])
 })
 
 test_that("reading a partitioned Parquet register works as expected", {
   actual <- read_register(temp_output) |> dplyr::collect()
 
-  expected <- purrr::map(file_paths, \(file_path) haven::read_sas(file_path)) |>
+  expected <- purrr::map(path, \(file_path) haven::read_sas(file_path)) |>
     dplyr::bind_rows()
 
   # Sort both dataframes by cpr and dw_ek_kontakt to ensure consistent ordering,
@@ -53,7 +53,7 @@ test_that("reading a partitioned Parquet register works as expected", {
     ignore_attr = TRUE
   )
 
-  expect_equal(sort(unique(actual$source_file)), sort(file_paths))
+  expect_equal(sort(unique(actual$source_file)), sort(path))
   expect_equal(sort(unique(actual$year), na.last = TRUE), c(1999, NA))
 })
 

--- a/tests/testthat/test-targets.R
+++ b/tests/testthat/test-targets.R
@@ -45,14 +45,14 @@ test_that("pipeline converts SAS files to Parquet", {
 
   # Create test SAS files.
   kontakter_list <- helper_create_simulated_kontakter(n = 1000)
-  paths <- fs::path(input_path) |>
+  path <- fs::path(input_path) |>
     paste0("/", names(kontakter_list), ".sas7bdat") |>
     as.character()
   temp_output <- fs::path_temp("kontakter")
 
-  suppressWarnings(haven::write_sas(kontakter_list[[1]], paths[[1]]))
-  suppressWarnings(haven::write_sas(kontakter_list[[2]], paths[[2]]))
-  suppressWarnings(haven::write_sas(kontakter_list[[3]], paths[[3]]))
+  suppressWarnings(haven::write_sas(kontakter_list[[1]], path[[1]]))
+  suppressWarnings(haven::write_sas(kontakter_list[[2]], path[[2]]))
+  suppressWarnings(haven::write_sas(kontakter_list[[3]], path[[3]]))
 
   # Read template and replace placeholder paths.
   modified_content <- template_content |>


### PR DESCRIPTION
# Description

Following what `fs` does. E.g., https://fs.r-lib.org/reference/copy.html#arg-path.

I'm updating the design vignette and found that it would be nice to simplify this so we don't have `path` and `file_paths`, and potentially `dir` as well.

This only updates code and not the design vignette.

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
