### PR TITLE
refactor: :recycle: longer UUIDs for less chance of duplicates

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -149,11 +149,11 @@ get_year_from_filename <- function(file_path) {
 #' We're using shortened UUIDs instead of integers to avoid collisions when
 #' converting registers in parallel.
 #'
-#' @returns A character scalar with a UUID with a length of 4.
+#' @returns A character scalar with a UUID with a length of 6.
 #'
 #' @keywords internal
 create_part_uuid <- function() {
-  substr(uuid::UUIDgenerate(), 0, 4)
+  substr(uuid::UUIDgenerate(), 0, 6)
 }
 
 #' Create a consistent Arrow schema from a data frame

--- a/man/create_part_uuid.Rd
+++ b/man/create_part_uuid.Rd
@@ -7,7 +7,7 @@
 create_part_uuid()
 }
 \value{
-A character scalar with a UUID with a length of 4.
+A character scalar with a UUID with a length of 6.
 }
 \description{
 We're using shortened UUIDs instead of integers to avoid collisions when


### PR DESCRIPTION
# Description

Instead of 4. Just to lower the risk of duplicates even more.

Needs no review.

## Checklist

- [X] Ran `just run-all`
