### PR TITLE
docs: :pencil2: specify `year` param in `simulate_register()` doc

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -5,8 +5,9 @@
 #'
 #' @param register Name of the register. Has to be a register accepted by
 #'  osdc::simulate_registers().
-#' @param year Year of the register as a character. Is appended to the register
-#'  name to form the list element names.
+#' @param year A character vector of year suffixes appended to the register
+#'  name to form the list element names (e.g., `"2020"`, `"1999_1"`, or
+#'  `""` for no suffix).
 #' @param n Number of rows to simulate per year.
 #'
 #' @returns A named list of tibble(s) with names in the format

--- a/man/simulate_register.Rd
+++ b/man/simulate_register.Rd
@@ -10,8 +10,9 @@ simulate_register(register, year = "", n = 1000)
 \item{register}{Name of the register. Has to be a register accepted by
 osdc::simulate_registers().}
 
-\item{year}{Year of the register as a character. Is appended to the register
-name to form the list element names.}
+\item{year}{A character vector of year suffixes appended to the register
+name to form the list element names (e.g., \code{"2020"}, \code{"1999_1"}, or
+\code{""} for no suffix).}
 
 \item{n}{Number of rows to simulate per year.}
 }


### PR DESCRIPTION
# Description

Needs no review.
