### PR TITLE
refactor: :recycle: add internal `create_partition_path()`

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -83,7 +83,6 @@ convert_file_in_chunks <- function(
   output_dir,
   chunk_size = 10000000L
 ) {
-
   # Prepare variables used in repeat below.
   partition_path <- create_partition_path(path, output_dir)
   part <- create_part_uuid()
@@ -117,6 +116,9 @@ convert_file_in_chunks <- function(
       column_names_to_lower() |>
       dplyr::mutate(source_file = as.character(path))
   }
+
+  invisible(path)
+}
 
 #' Create partition path
 #'


### PR DESCRIPTION
# Description

Moving the creation of the partition path to its own function to make `convert_file_in_chunks()` a bit cleaner.

Needs no review.

## Checklist

- [X] Ran `just run-all`
