### PR TITLE
refactor: :recycle: add internal `check_parquet_path`

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -26,21 +26,7 @@ read_register <- function(
     checkmate::check_file_exists(path),
     checkmate::check_directory_exists(path)
   )
-  if (
-    fs::is_dir(path) &&
-      length(fs::dir_ls(path, regexp = "\\.(parquet|parq)$", recurse = TRUE)) ==
-        0
-  ) {
-    cli::cli_abort("The path {path} does not contain any Parquet files.")
-  } else if (
-    fs::is_file(path) &&
-      fs::path_ext(path) != "parquet" &&
-      fs::path_ext(path) != "parq"
-  ) {
-    cli::cli_abort(
-      "The path {path} must have a `.parquet` or `.parq` extension."
-    )
-  }
+  check_parquet_path(path)
 
   # If input path is a directory, read as partitioned Parquet register,
   # else read as Parquet file.
@@ -51,6 +37,35 @@ read_register <- function(
   }
 }
 
+
+#' Check whether path is to a Parquet file or directory with Parquet files.
+#'
+#' @inheritParams read_register
+#'
+#' @returns `path` invisibly.
+#'
+#' @keywords internal
+#' @noRd
+check_parquet_path <- function(path) {
+  if (
+    fs::is_dir(path) &&
+      length(fs::dir_ls(path, regexp = "\\.(parquet|parq)$", recurse = TRUE)) ==
+        0
+  ) {
+    cli::cli_abort(
+      "The path {.path {path}} does not contain any Parquet files."
+    )
+  } else if (
+    fs::is_file(path) &&
+      fs::path_ext(path) != "parquet" &&
+      fs::path_ext(path) != "parq"
+  ) {
+    cli::cli_abort(
+      "The path {.path {path}} must have a {.val .parquet} or {.val .parq} extension."
+    )
+  }
+  invisible(path)
+}
 
 #' Read a partitioned Parquet register as DuckDB table
 #'


### PR DESCRIPTION
# Description

For a cleaner flow in `read_register()`.

Needs no review. 

## Checklist

- [X] Ran `just run-all`

