### PR TITLE
test: :white_check_mark: add `read_register()` test with `.parq` extension

### DIFF
--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -93,3 +93,9 @@ test_that("non-Parquet file returns error", {
 
   expect_error(read_register(temp_txt_file), temp_txt_file)
 })
+
+test_that("files with extension .parq can also be read", {
+  path <- fs::path_temp("file.parq")
+  arrow::write_parquet(simulate_register("kontakter")[[1]], sink = path)
+  expect_no_error(read_register(path))
+})


### PR DESCRIPTION
# Description

Needs no review. 

## Checklist

- [X] Ran `just run-all`

