### PR TITLE
chore: :wrench: remove auto-formatting of Markdown files in RStudio

### DIFF
--- a/fastreg.Rproj
+++ b/fastreg.Rproj
@@ -21,7 +21,3 @@ PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace
 
 UseNativePipeOperator: Yes
-
-MarkdownWrap: Column
-MarkdownWrapAtColumn: 72
-MarkdownCanonical: Yes


### PR DESCRIPTION
# Description

These settings auto-formatted while editing in RStudio, which messes with the rumdl formatter.

Needs a quick review.
