### PR TITLE
chore: :wrench: simplify EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,14 +6,8 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 72
-
-[*.{yaml,yml}]
-indent_size = 2
-
-[*.R]
-indent_size = 2


### PR DESCRIPTION
# Description

Use 2 spaces for indent, so don't need the other items in `.editorconfig`.

Needs a quick review.
