### PR TITLE
refactor: :truck: rename `chunk_info$columns` cols to be more descriptive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,8 @@ each release.
 
 ### Feat
 
-- :sparkles: `list_parquet_files()` and `list_parquet_datasets()` helpers (#272)
+- :sparkles: `list_parquet_files()` and `list_parquet_datasets()`
+  helpers (#272)
 
 ## 0.10.3 (2026-04-27)
 

--- a/R/convert.R
+++ b/R/convert.R
@@ -63,8 +63,8 @@ convert <- function(
         output_path = fs::path(file_path),
         row_count = nrow(chunk),
         columns = list(tibble::tibble(
-          name = colnames(chunk),
-          type = purrr::map_chr(chunk, class)
+          column_name = colnames(chunk),
+          data_type = purrr::map_chr(chunk, class)
         ))
       )
     )


### PR DESCRIPTION
# Description

Which will also be a little nicer for the conversion log. 

Needs no review.

## Checklist

- [ ] Ran `just run-all`
