### PR TITLE
build: :bug: remove ending `png` that is added by Quarto in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- badges: start -->
 
 [![CRAN
-status](https://www.r-pkg.org/badges/version/fastreg.png)](https://CRAN.R-project.org/package=fastreg)
+status](https://www.r-pkg.org/badges/version/fastreg)](https://CRAN.R-project.org/package=fastreg)
 [![GitHub
 Release](https://img.shields.io/github/v/release/dp-next/fastreg.svg)](https://github.com/dp-next/fastreg/releases/latest)
 [![Build](https://github.com/dp-next/fastreg/actions/workflows/build.yml/badge.svg)](https://github.com/dp-next/fastreg/actions/workflows/build.yml)

--- a/justfile
+++ b/justfile
@@ -104,6 +104,7 @@ build-docs: _build-rd _build-website _build-readme
 # Re-build the README file from the Quarto version
 @_build-readme:
   uvx --from quarto quarto render README.qmd --to gfm
+  sed -i "s/fastreg\\.png/fastreg/" README.md
 
 # Preview website locally
 preview-website:


### PR DESCRIPTION
# Description

This triggers the URL checker. So fixes this by removing the `.png` from the image URL in the README.

Needs a no review.

## Checklist

- [x] Ran `just run-all`
