### PR TITLE
refactor: :recycle: make `if else` stricter with `if_else()`

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -111,7 +111,11 @@ create_partition_path <- function(path, output_dir) {
   year <- get_year_from_filename(path)
   # Following the default `null_fallback` in arrow::hive_partition()
   # https://arrow.apache.org/docs/r/reference/hive_partition.html#arg-null-fallback.
-  year_partition <- if (is.na(year)) "__HIVE_DEFAULT_PARTITION__" else year
+  year_partition <- dplyr::if_else(
+    is.na(year),
+    "__HIVE_DEFAULT_PARTITION__",
+    as.character(year)
+  )
   partition_path <- fs::path(
     output_dir,
     get_register_name(path),


### PR DESCRIPTION
# Description

Very minor change I noticed while I was trying to solve an issue. `if_else()` is stricter and better to use when assigning to a variable.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
