### PR TITLE
fix: :bug: change `skip` to `double` to avoid integer overflow with very large files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,8 @@ each release.
 
 ### Refactor
 
-- ♻️ `read_register()` takes a register name as argument, not path (#299)
+- ♻️ `read_register()` takes a register name as argument, not path
+  (#299)
 
 ## 0.12.4 (2026-06-02)
 

--- a/R/convert.R
+++ b/R/convert.R
@@ -34,7 +34,7 @@ convert <- function(
   # Prepare variables used in repeat below.
   partition_path <- create_partition_path(path, output_dir)
   part <- create_part_uuid()
-  skip <- 0L
+  skip <- 0 # Not integer (0L) since they overflow at ~2.1B rows, doubles don't.
   conversion_log <- tibble::tribble(~register_name, ~input_path, ~output_path, ~row_count, ~schema)
 
   # Read first chunk to establish schema.

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -8,7 +8,7 @@ bef_list <- simulate_registers_with_paths(
 sas_paths <- bef_list |>
   purrr::pwalk(write_to_sas)
 
-# Test convert() ----------------------------------------------------------
+# Test convert() ---------------------------------------------------------------
 
 # Setup: Convert single file
 single_file_path <- fs::path_temp("parquet_single_file")
@@ -126,4 +126,35 @@ test_that("convert() creates expected n parts when chunk_size < nrow", {
     type = "file"
   ))
   expect_equal(n_actual, n_expected)
+})
+
+
+test_that("convert() handles very large files without integer overflow", {
+  chunk_size <- 1073741824L # Two chunks overflow int32 max.
+  total_rows <- 2500000000
+
+  # Replace read_sas_chunk so it returns an empty tibble that "reports" the
+  # right number of rows.
+  local_mocked_bindings(
+    read_sas_chunk = function(path, skip, chunk_size) {
+      # Return 0 rows if `skip` becomes NA to catch the expected integer
+      # overflow with int32.
+      rows_remaining <- if (is.na(skip)) 0 else total_rows - skip
+      tibble::new_tibble(
+        list(),
+        nrow = as.integer(min(chunk_size, rows_remaining))
+      )
+    },
+    .package = "fastreg"
+  )
+
+  result <- expect_no_warning(
+    convert(
+      path = sas_paths$output_path[1],
+      output_dir = fs::path_temp("large_overflow_test"),
+      chunk_size = chunk_size
+    )
+  )
+
+  expect_equal(sum(result$row_count), total_rows)
 })


### PR DESCRIPTION
# Description

This PR first adds a test that exposes the integer overflow error when `skip` becomes too large (larger than the int32 max, see [this failed workflow](https://github.com/dp-next/fastreg/actions/runs/26880609236/job/79279394082#step:6:193), and then adds a fix to it. 

Closes #302 

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
