### PR TITLE
fix: :bug: handle data types with class vectors of length > 1 in `convert()`

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -65,7 +65,8 @@ convert <- function(
         row_count = nrow(chunk),
         schema = list(tibble::tibble(
           column_name = colnames(chunk),
-          data_type = purrr::map_chr(chunk, class)
+          # Choose first class in case there's multiple (e.g., POSIXct and POSIXt).
+          data_type = purrr::map_chr(chunk, \(x) class(x)[1])
         ))
       )
     )

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -158,3 +158,25 @@ test_that("convert() handles very large files without integer overflow", {
 
   expect_equal(sum(result$row_count), total_rows)
 })
+
+test_that("convert()'s conversion log handles data types with class vectors of length > 1", {
+  df <- simulate_registers_with_paths("bef", n = 1000)
+
+  # Change `foed_dato` to POSIXct (so class vector has len > 1, "POSIXct" *and* "POSIXt")
+  df$data[[1]] <- df$data[[1]] |>
+    dplyr::mutate(foed_dato = as.POSIXct(foed_dato))
+
+  sas_path <- df |>
+    purrr::pwalk(write_to_sas)
+
+  result <- expect_no_error(convert(
+    path = sas_path$output_path,
+    output_dir = fs::path_temp("class-vector")
+  ))
+
+  foed_dato_type <- result$schema[[1]] |>
+    dplyr::filter(column_name == "foed_dato") |>
+    dplyr::pull(data_type)
+
+  expect_equal(foed_dato_type, "POSIXct")
+})

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -176,7 +176,8 @@ test_that("convert()'s conversion log handles data types with class vectors of l
 
   foed_dato_type <- result$schema[[1]] |>
     dplyr::filter(column_name == "foed_dato") |>
-    dplyr::pull(data_type)
+    dplyr::pull(data_type) |>
+    unname()
 
   expect_equal(foed_dato_type, "POSIXct")
 })


### PR DESCRIPTION
# Description

Before this fix, `convert()` errored when a data type has a class vector with a length > 1, for example "POSIXct" that has both "POSIXct" and "POSIXt" when you run `class()`.

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
