### PR TITLE
fix: :bug: import `list_sas_files()` from `fastreg` in template

### DIFF
--- a/inst/template-targets.R
+++ b/inst/template-targets.R
@@ -21,7 +21,7 @@ library(tarchetypes)
 
 config <- list(
   # Paths to SAS files
-  sas_paths = list_sas_files("/path/to/sas/directory"),
+  sas_paths = fastreg::list_sas_files("/path/to/sas/directory"),
   # Path to output Parquet files in. Parquet files will be located in
   # subdirectories of this directory.
   output_dir = "/path/to/output/directory"


### PR DESCRIPTION
# Description

Otherwise, I get the error `Could not find function "list_sas_files"`. Since this function is run outside the pipeline/before tar_option_set, the function isn't available otherwise.

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
