### PR TITLE
fix: 🐛 lowercase register names and keep underscores

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,8 @@ each release.
 
 ### Fix
 
-- 🐛 handle data types with class vectors of length > 1 in `convert()` (#314)
+- 🐛 handle data types with class vectors of length > 1 in `convert()`
+  (#314)
 
 ## 0.13.0 (2026-06-04)
 

--- a/R/convert.R
+++ b/R/convert.R
@@ -221,8 +221,8 @@ get_register_names <- function(path) {
   path |>
     fs::path_file() |>
     fs::path_ext_remove() |>
-    # Remove everything that's not a letter.
-    stringr::str_remove_all("[^[:alpha:]]")
+    # Remove everything that's not a letter except underscores.
+    stringr::str_remove_all("[^[:alpha:]_]")
 }
 
 #' Get register name from a group of file paths

--- a/R/convert.R
+++ b/R/convert.R
@@ -222,7 +222,8 @@ get_register_names <- function(path) {
     fs::path_file() |>
     fs::path_ext_remove() |>
     # Remove everything that's not a letter except underscores.
-    stringr::str_remove_all("[^[:alpha:]_]")
+    stringr::str_remove_all("[^[:alpha:]_]") |>
+    stringr::str_to_lower()
 }
 
 #' Get register name from a group of file paths

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -181,3 +181,20 @@ test_that("convert()'s conversion log handles data types with class vectors of l
 
   expect_equal(foed_dato_type, "POSIXct")
 })
+
+test_that("convert() only keep lowercased letters and underscores in register names", {
+  df <- simulate_registers_with_paths("bef", n = 10)
+  df$output_path <- df$output_path |>
+    fs::path_dir() |>
+    fs::path("r€EG|i-s$ter-_NAME.sas7bdat")
+
+  sas_path <- df |>
+    purrr::pwalk(write_to_sas)
+
+  result <- expect_no_error(convert(
+    path = sas_path$output_path,
+    output_dir = fs::path_temp("register-name")
+  ))
+
+  expect_equal(result$register_name, "register_name")
+})

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -186,7 +186,7 @@ test_that("convert() only keep lowercased letters and underscores in register na
   df <- simulate_registers_with_paths("bef", n = 10)
   df$output_path <- df$output_path |>
     fs::path_dir() |>
-    fs::path("r€EG|i-s$ter-_NAME.sas7bdat")
+    fs::path("r€EGI-s$ter-_NAME.sas7bdat")
 
   sas_path <- df |>
     purrr::pwalk(write_to_sas)

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -186,7 +186,7 @@ test_that("convert() only keep lowercased letters and underscores in register na
   df <- simulate_registers_with_paths("bef", n = 10)
   df$output_path <- df$output_path |>
     fs::path_dir() |>
-    fs::path("r€EGI-s$ter-_NAME.sas7bdat")
+    fs::path("r€EGI-s$ ter_NAME.sas7bdat")
 
   sas_path <- df |>
     purrr::pwalk(write_to_sas)


### PR DESCRIPTION
# Description

If we don't keep underscores, the registers get some quite unreadable names, like `lprakontaktlokation`, `lprahenvisningtillaeg`. Now that I was at it, I also made the register names lowercased.

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
