### PR TITLE
refactor: ♻️ truncate input and output paths in `print_log_row_count()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,8 @@ each release.
 
 ### Fix
 
-- 🐛 handle data types with class vectors of length > 1 in `convert()` (#314)
+- 🐛 handle data types with class vectors of length > 1 in `convert()`
+  (#314)
 
 ## 0.13.0 (2026-06-04)
 

--- a/R/log.R
+++ b/R/log.R
@@ -15,9 +15,10 @@
 #' print_log_row_count(conversion_log)
 print_log_row_count <- function(log) {
   log |>
-    dplyr::mutate(
-      dplyr::across(c("input_path", "output_path"), fs::path_rel)
-    ) |>
+    dplyr::mutate(dplyr::across(c("input_path", "output_path"), \(path) {
+      fs::path_rel(path) |>
+        stringr::str_trunc(width = 50, side = "left")
+    })) |>
     dplyr::select("input_path", "output_path", "row_count") |>
     knitr::kable() |>
     print()

--- a/R/log.R
+++ b/R/log.R
@@ -21,7 +21,9 @@ print_log_row_count <- function(log) {
         stringr::str_trunc(width = 50, side = "left")
     })) |>
     dplyr::select("input_path", "output_path", "row_count") |>
-    knitr::kable() |>
+    knitr::kable(
+      col.names = c("Input (.sas7bdat)", "Output (.parquet)", "Row count")
+    ) |>
     print()
 
   invisible(log)

--- a/R/log.R
+++ b/R/log.R
@@ -17,6 +17,7 @@ print_log_row_count <- function(log) {
   log |>
     dplyr::mutate(dplyr::across(c("input_path", "output_path"), \(path) {
       fs::path_rel(path) |>
+        fs::path_ext_remove() |>
         stringr::str_trunc(width = 50, side = "left")
     })) |>
     dplyr::select("input_path", "output_path", "row_count") |>

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -63,13 +63,13 @@ test_that("print_log_row_count() returns input invisibly", {
   expect_equal(actual, log_bef)
 })
 
-test_that("print_log_row_count() renders SAS paths in output", {
-  expect_match(
-    log_row_count,
-    ".sas7bdat",
-    all = FALSE,
-    fixed = TRUE
-  )
+test_that("print_log_row_count() includes SAS file names (no ext) in table rows", {
+  file_names <- bef$output_path |> fs::path_file() |> fs::path_ext_remove()
+  table_rows <- stringr::str_subset(log_row_count, "\\|")[-c(1:2)]
+
+  purrr::walk(file_names, \(file_name) {
+    expect_match(table_rows, file_name, all = FALSE, fixed = TRUE)
+  })
 })
 
 test_that("print_log_row_count() renders row count values in output", {


### PR DESCRIPTION
# Description

In my tryout on DST, the paths are too long and overlap, so this truncates them to be a max of 50 characters.

I've also removed the file extensions from `input_path` and `output_path` and moved them to the column headers ("Input (.sas7dbat)" and "Output (.parquet")", since they'll be the same for all rows.

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
