### PR TITLE
docs: :fire: remove `get_*()` functions from pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,7 +19,6 @@ reference:
   - title: Helper functions
   - contents:
       - starts_with("list")
-      - starts_with("get")
       - write_to_sas
       - simulate_registers_with_paths
   - title: Log functions


### PR DESCRIPTION
# Description

Since they are all internal at this point.

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
