### PR TITLE
fix: 🐛 import `targets` in log qmd to set explicit dependency

### DIFF
--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -21,8 +21,9 @@ If you experience any problems or bugs with `fastreg`, please add an
 #| echo: false
 #| message: false
 #| results: asis
+library(targets)
 
-conversion_log <- targets::tar_read(conversion_log)
+conversion_log <- tar_read(conversion_log)
 
 for (register in unique(conversion_log$register_name)) {
   register_log <- conversion_log |>


### PR DESCRIPTION
# Description

So the PDF won't be created (from previous conversion logs) before the conversion is done in the new run.

NB: I'm not entirely sure why this works, but it seems to do the trick. It is aligned with the example for [`tar_render()`](https://books.ropensci.org/targets/literate-programming.html#r-markdown-targets) in the targets book though.
Alternatively, we could add a `execute_params` in the targets pipeline and in template yml header (`conversion-log: null`) as described under [`tar_quarto()`](https://books.ropensci.org/targets/literate-programming.html#single-parameter-set).

Needs a thorough review.

## Checklist

- [ ] Ran `just run-all`
