### PR TITLE
refactor: :lipstick: prettify log table column names

### DIFF
--- a/R/log.R
+++ b/R/log.R
@@ -80,7 +80,7 @@ print_log_schema <- function(register_log) {
       get_schema_diffs(file_schemas, reference_schema) |>
         chunk_diff_table() |>
         purrr::map(\(chunk) {
-          dplyr::rename(chunk, "Column name" = column_name)
+          dplyr::rename(chunk, "Column name" = "column_name")
         }) |>
         purrr::map_chr(collapse_kable)
     )
@@ -91,7 +91,7 @@ print_log_schema <- function(register_log) {
     description,
     # Reference schema.
     reference_schema |>
-      dplyr::rename("Column name" = column_name, "Data type" = data_type) |>
+      dplyr::rename("Column name" = "column_name", "Data type" = "data_type") |>
       collapse_kable(),
     # Schema differences.
     schema_differences

--- a/R/log.R
+++ b/R/log.R
@@ -79,6 +79,9 @@ print_log_schema <- function(register_log) {
       "",
       get_schema_diffs(file_schemas, reference_schema) |>
         chunk_diff_table() |>
+        purrr::map(\(chunk) {
+          dplyr::rename(chunk, "Column name" = column_name)
+        }) |>
         purrr::map_chr(collapse_kable)
     )
   }
@@ -87,7 +90,9 @@ print_log_schema <- function(register_log) {
     # Description.
     description,
     # Reference schema.
-    collapse_kable(reference_schema),
+    reference_schema |>
+      dplyr::rename("Column name" = column_name, "Data type" = data_type) |>
+      collapse_kable(),
     # Schema differences.
     schema_differences
   )

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -64,7 +64,9 @@ test_that("print_log_row_count() returns input invisibly", {
 })
 
 test_that("print_log_row_count() includes SAS file names (no ext) in table rows", {
-  file_names <- bef$output_path |> fs::path_file() |> fs::path_ext_remove()
+  file_names <- bef$output_path |>
+    fs::path_file() |>
+    fs::path_ext_remove()
   table_rows <- stringr::str_subset(log_row_count, "\\|")[-c(1:2)]
 
   purrr::walk(file_names, \(file_name) {


### PR DESCRIPTION
# Description

I.e., capitalise and split words with space instead of underscore.

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
