### PR TITLE
refactor: :recycle: don't open targets pipeline in Rstudio

### DIFF
--- a/R/use.R
+++ b/R/use.R
@@ -48,7 +48,7 @@ use_template <- function(
     cli::cli_alert_info("Edit the {.code config} section to set your paths.")
   }
 
-  if (open && Sys.getenv("Rstudio") != "1") {
+  if (open && .Platform$GUI == "RStudio") {
     utils::file.edit(target_file)
   }
 

--- a/R/use.R
+++ b/R/use.R
@@ -48,7 +48,7 @@ use_template <- function(
     cli::cli_alert_info("Edit the {.code config} section to set your paths.")
   }
 
-  if (open) {
+  if (open && Sys.getenv("Rstudio") != "1") {
     utils::file.edit(target_file)
   }
 


### PR DESCRIPTION
# Description

Currently it's opened in a separate window, which isn't that nice. It works well in Positron though.

Needs a thorough review.

## Checklist

- [ ] Ran `just run-all`
