### PR TITLE
refactor: :recycle: use raw link to new fastreg issue in conversion log qmd

### DIFF
--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -15,7 +15,8 @@ For each register, this log includes two sections:
    schema is shown alongside the differences.
 
 If you experience any problems or bugs with `fastreg`, please add an
-[issue on GitHub](https://github.com/dp-next/fastreg/issues/new).
+issue on GitHub by following this link:
+<https://github.com/dp-next/fastreg/issues/new>.
 
 ```{r}
 #| echo: false


### PR DESCRIPTION
# Description

Since users on Denmark's statistics don't have access to the internet, they won't be able to follow the hyperlink.

Needs a quick review.
