### PR TITLE
refactor: ♻️ abort `convert()` if `skip` becomes `NA`

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -71,7 +71,9 @@ convert <- function(
       )
     )
 
+    skip_before <- skip
     skip <- skip + nrow(chunk)
+    abort_if_skip_na(skip, skip_before, chunk, path)
     part <- create_part_uuid()
 
     chunk <- read_sas_chunk(path, skip, chunk_size)
@@ -80,6 +82,16 @@ convert <- function(
   cli::cli_alert_success("Converted {.path {fs::path_file(path)}}")
 
   conversion_log
+}
+
+#' @noRd
+abort_if_skip_na <- function(skip, skip_before, chunk, path) {
+  if (is.na(skip)) {
+    cli::cli_abort(c(
+      "skip became NA while converting {.path {path}}. Aborting.",
+      "i" = "skip was {skip_before} before and chunk has {nrow(chunk)} rows."
+    ))
+  }
 }
 
 #' Read SAS chunk

--- a/R/convert.R
+++ b/R/convert.R
@@ -73,7 +73,16 @@ convert <- function(
 
     skip_before <- skip
     skip <- skip + nrow(chunk)
-    abort_if_skip_na(skip, skip_before, chunk, path)
+
+    if (is.na(skip)) {
+      cli::cli_warn(c(
+        "The conversion ended early because of an issue with {.path {path}}.",
+        "i" = "{skip_before} rows of this file were converted before the issue occurred.",
+        "i" = "If the issue persists, please file a bug report here: {.url https://github.com/dp-next/fastreg}."
+      ))
+      break
+    }
+
     part <- create_part_uuid()
 
     chunk <- read_sas_chunk(path, skip, chunk_size)
@@ -83,17 +92,6 @@ convert <- function(
 
   conversion_log
 }
-
-#' @noRd
-abort_if_skip_na <- function(skip, skip_before, chunk, path) {
-  if (is.na(skip)) {
-    cli::cli_abort(c(
-      "skip became NA while converting {.path {path}}. Aborting.",
-      "i" = "skip was {skip_before} before and chunk has {nrow(chunk)} rows."
-    ))
-  }
-}
-
 #' Read SAS chunk
 #'
 #' @param skip Number of rows to skip.

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -159,18 +159,6 @@ test_that("convert() handles very large files without integer overflow", {
   expect_equal(sum(result$row_count), total_rows)
 })
 
-test_that("convert() aborts if skip becomes NA", {
-  expect_error(
-    abort_if_skip_na(
-      skip = NA,
-      skip_before = 10,
-      chunk = data_actual,
-      path = sas_paths$output_path[1]
-    ),
-    regexp = "NA"
-  )
-})
-
 test_that("convert()'s conversion log handles data types with class vectors of length > 1", {
   df <- simulate_registers_with_paths("bef", n = 1000)
 

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -159,6 +159,18 @@ test_that("convert() handles very large files without integer overflow", {
   expect_equal(sum(result$row_count), total_rows)
 })
 
+test_that("convert() aborts if skip becomes NA", {
+  expect_error(
+    abort_if_skip_na(
+      skip = NA,
+      skip_before = 10,
+      chunk = data_actual,
+      path = sas_paths$output_path[1]
+    ),
+    regexp = "NA"
+  )
+})
+
 test_that("convert()'s conversion log handles data types with class vectors of length > 1", {
   df <- simulate_registers_with_paths("bef", n = 1000)
 


### PR DESCRIPTION
# Description

Otherwise, Anders mentioned, that the repeat just continues until stopped manually. To avoid that, I've added a break and a warning, in case that happens.

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
