### PR TITLE
fix: :bug: don't open a new targets pipeline in RStudio

### DIFF
--- a/R/use.R
+++ b/R/use.R
@@ -48,7 +48,7 @@ use_template <- function(
     cli::cli_alert_info("Edit the {.code config} section to set your paths.")
   }
 
-  if (open && .Platform$GUI == "RStudio") {
+  if (open && .Platform$GUI != "RStudio") {
     utils::file.edit(target_file)
   }
 


### PR DESCRIPTION
# Description

I accidentally wrote `==` instead of `!=` earlier in #322 

Needs a quick review.

## Checklist

- [ ] Ran `just run-all`
