### PR TITLE
fix: :bug: warn when SAS data has >32bit rows on Windows, return 0

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -5,6 +5,11 @@
 #' Existing data will not be overwritten, but might be duplicated if it already
 #' exists in the directory, since files are saved with UUIDs in their names.
 #'
+#' On Windows, `haven::read_sas()` silently re-reads the first chunk when
+#' `skip` exceeds 2,147,483,647 (the 32-bit integer limit).
+#' `convert()` detects this and stops the conversion with a warning, so
+#' the remainder of the file is not converted.
+#'
 #' @param path Path to a single SAS file.
 #' @param output_dir Directory to save the Parquet output to. Must not include
 #'  the register name as this will be extracted from `path` to create the
@@ -14,6 +19,9 @@
 #' @returns A tibble with a conversion log about each written chunk.
 #'
 #' @export
+#' @seealso [Getting started](https://dp-next.github.io/fastreg/articles/fastreg.html)
+#'   and the [When SAS files become too big](https://dp-next.github.io/fastreg/articles/fastreg.html#sec-large-sas-files)
+#'   section for handling SAS files with more than 2,147,483,647 rows.
 #' @examples
 #' sas_file <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
 #' convert(

--- a/R/convert.R
+++ b/R/convert.R
@@ -105,7 +105,7 @@ convert <- function(
 #'
 #' @noRd
 read_sas_chunk <- function(path, skip, chunk_size) {
-  if (skip > 2147483647 && .Platform$OS.type == "windows") {
+  if (!is.na(skip) && skip > 2147483647 && .Platform$OS.type == "windows") {
     cli::cli_warn(
       c(
         "Could not read {.path {fs::path_file(path)}} from row {format(skip, big.mark = ',')} onwards.",

--- a/R/convert.R
+++ b/R/convert.R
@@ -94,17 +94,33 @@ convert <- function(
 }
 #' Read SAS chunk
 #'
+#' On Windows, skip > 2,147,483,647 overflows readstat's 32-bit row position,
+#' causing it (and thereby haven's read_sas() function) to read from row 0.
+#' This function returns an empty tibble instead.
+#'
 #' @param skip Number of rows to skip.
 #' @inheritParams convert
 #'
 #' @returns A tibble.
 #'
-#' @keywords internal
 #' @noRd
 read_sas_chunk <- function(path, skip, chunk_size) {
-  haven::read_sas(path, skip = skip, n_max = chunk_size) |>
-    column_names_to_lower() |>
-    dplyr::mutate(source_file = as.character(path))
+  if (skip > 2147483647 && .Platform$OS.type == "windows") {
+    cli::cli_warn(
+      c(
+        "Could not read {.path {fs::path_file(path)}} from row {format(skip, big.mark = ',')} onwards.",
+        "i" = "This is a Windows limitation: row positions above the 32-bit limit (2,147,483,647) cannot be read.",
+        "i" = "If your file has more than 2,147,483,647 rows, the output is incomplete. Consider splitting the file before converting."
+      )
+    )
+    haven::read_sas(path, n_max = 0) |>
+      column_names_to_lower() |>
+      dplyr::mutate(source_file = as.character(path))
+  } else {
+    haven::read_sas(path, skip = skip, n_max = chunk_size) |>
+      column_names_to_lower() |>
+      dplyr::mutate(source_file = as.character(path))
+  }
 }
 
 #' Create partition path

--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -32,7 +32,8 @@ pipeline_warnings <- tar_meta(fields = warnings, complete_only = TRUE)
 
 if (nrow(pipeline_warnings) > 0) {
   cat("## Warnings\n\n")
-  cat("The pipeline produced the following warning(s).",
+  cat(
+    "The pipeline produced the following warning(s).",
     "Please review them before proceeding:\n\n"
   )
   knitr::kable(pipeline_warnings)

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -24,10 +24,21 @@ chunks. It does not check for existing files in the output directory.
 Existing data will not be overwritten, but might be duplicated if it already
 exists in the directory, since files are saved with UUIDs in their names.
 }
+\details{
+On Windows, \code{haven::read_sas()} silently re-reads the first chunk when
+\code{skip} exceeds 2,147,483,647 (the 32-bit integer limit).
+\code{convert()} detects this and stops the conversion with a warning, so
+the remainder of the file is not converted.
+}
 \examples{
 sas_file <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
 convert(
   path = sas_file,
   output_dir = fs::path_temp("path/to/output/file")
 )
+}
+\seealso{
+\href{https://dp-next.github.io/fastreg/articles/fastreg.html}{Getting started}
+and the \href{https://dp-next.github.io/fastreg/articles/fastreg.html#sec-large-sas-files}{When SAS files become too big}
+section for handling SAS files with more than 2,147,483,647 rows.
 }

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -186,9 +186,9 @@ test_that("read_sas_chunk() returns 0 rows when skip is exactly the 32-bit limit
 })
 
 
-test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-bit limit on Windows", {
-  # Only run on Windows.
-  skip_on_os(c("linux", "mac", "solaris"))
+test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-bit limit", {
+  # This test should be the same on all operating systems now that we explicitly
+  # return an empty tibble when skip exceeds 32-bit limit in read_sas_chunk().
   path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
   data <- haven::read_sas(path)
   max_32_bit <- 2147483647

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -185,12 +185,10 @@ test_that("read_sas_chunk() returns 0 rows when skip is exactly the 32-bit limit
   expect_equal(nrow(chunk), 0L)
 })
 
-
-test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-bit limit", {
-  # This test should be the same on all operating systems now that we explicitly
-  # return an empty tibble when skip exceeds 32-bit limit in read_sas_chunk().
+test_that("read_sas_chunk() returns first chunk when skip is NA and empty tibble when skip exceeds the 32-bit limit", {
+  # Should be the same on all operating systems now that we explicitly return an
+  # empty tibble when skip exceeds 32-bit limit in read_sas_chunk().
   path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
-  data <- haven::read_sas(path)
   max_32_bit <- 2147483647
   chunk_skip_na <- read_sas_chunk(
     path,
@@ -203,7 +201,11 @@ test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-b
     chunk_size = 100L
   )
 
-  expect_equal(chunk_skip_na, chunk_skip_over_32_bit)
+  expect_equal(
+    chunk_skip_na |> dplyr::select(-"source_file"),
+    haven::read_sas(path, n_max = 100L)
+  )
+  expect_equal(nrow(chunk_skip_over_32_bit), 0L)
 })
 
 test_that("convert()'s conversion log handles data types with class vectors of length > 1", {

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -174,6 +174,18 @@ test_that("read_sas_chunk() returns 0 rows when skip exceeds 32-bit limit", {
   expect_equal(nrow(chunk), 0L)
 })
 
+test_that("read_sas_chunk() returns 0 rows when skip is exactly the 32-bit limit", {
+  path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
+  max_32_bit <- 2147483647
+  chunk <- read_sas_chunk(
+    path,
+    skip = 2147483647,
+    chunk_size = 1000L
+  )
+  expect_equal(nrow(chunk), 0L)
+})
+
+
 test_that("convert()'s conversion log handles data types with class vectors of length > 1", {
   df <- simulate_registers_with_paths("bef", n = 1000)
 

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -129,8 +129,8 @@ test_that("convert() creates expected n parts when chunk_size < nrow", {
 })
 
 
-test_that("convert() handles very large files without integer overflow", {
-  chunk_size <- 1073741824L # Two chunks overflow int32 max.
+test_that("convert()'s skip doesn't become NA when passing the 32-bit integer limit", {
+  chunk_size <- 1073741824L # Two chunks exceed 32 bit integer max (2,147,483,647).
   total_rows <- 2500000000
 
   # Replace read_sas_chunk so it returns an empty tibble that "reports" the
@@ -157,6 +157,21 @@ test_that("convert() handles very large files without integer overflow", {
   )
 
   expect_equal(sum(result$row_count), total_rows)
+})
+
+test_that("read_sas_chunk() returns 0 rows when skip exceeds 32-bit limit", {
+  # The current hypothesis is that on Windows, `skip` values above the 32-bit
+  # max overflow C's 32-bit `long`, causing readstat to read from row 0 (as
+  # observed on DST/Windows) instead of returning 0 rows, causing an infinite
+  # repeat loop in convert()
+  path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
+  max_32_bit <- 2147483647
+  chunk <- read_sas_chunk(
+    path,
+    skip = max_32_bit + 1,
+    chunk_size = 1000L
+  )
+  expect_equal(nrow(chunk), 0L)
 })
 
 test_that("convert()'s conversion log handles data types with class vectors of length > 1", {

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -160,10 +160,9 @@ test_that("convert()'s skip doesn't become NA when passing the 32-bit integer li
 })
 
 test_that("read_sas_chunk() returns 0 rows when skip exceeds 32-bit limit", {
-  # The current hypothesis is that on Windows, `skip` values above the 32-bit
-  # max overflow C's 32-bit `long`, causing readstat to read from row 0 (as
-  # observed on DST/Windows) instead of returning 0 rows, causing an infinite
-  # repeat loop in convert()
+  # Passes on all operating systems now. Without the fix in read_sas_chunk() to
+  # handle this, readstat overflows and starts to read from row 0 instead when
+  # run on Windows (as observed on DST).
   path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
   max_32_bit <- 2147483647
   chunk <- read_sas_chunk(
@@ -175,6 +174,10 @@ test_that("read_sas_chunk() returns 0 rows when skip exceeds 32-bit limit", {
 })
 
 test_that("read_sas_chunk() returns 0 rows when skip is exactly the 32-bit limit", {
+  # Was created to test that the overflow observed on Windows only happened when
+  # skip exceeds the 32-bit limit.
+  # The fix uses `>`, not `>=`, so skip = max_32_bit does not trigger it.
+  # This returns 0 rows because the test file has fewer rows than max_32_bit.
   path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
   max_32_bit <- 2147483647
   chunk <- read_sas_chunk(

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -186,6 +186,24 @@ test_that("read_sas_chunk() returns 0 rows when skip is exactly the 32-bit limit
 })
 
 
+test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-bit limit", {
+  path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
+  data <- haven::read_sas(path)
+  max_32_bit <- 2147483647
+  chunk_skip_na <- read_sas_chunk(
+    path,
+    skip = NA,
+    chunk_size = 100L
+  )
+  chunk_skip_over_32_bit <- read_sas_chunk(
+    path,
+    skip = max_32_bit + 1,
+    chunk_size = 100L
+  )
+
+  expect_equal(chunk_skip_na, chunk_skip_over_32_bit)
+})
+
 test_that("convert()'s conversion log handles data types with class vectors of length > 1", {
   df <- simulate_registers_with_paths("bef", n = 1000)
 

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -186,7 +186,9 @@ test_that("read_sas_chunk() returns 0 rows when skip is exactly the 32-bit limit
 })
 
 
-test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-bit limit", {
+test_that("read_sas_chunk() data is the same for skip NA and skip exceeding 32-bit limit on Windows", {
+  # Only run on Windows.
+  skip_on_os(c("linux", "mac", "solaris"))
   path <- fs::path_package("fastreg", "extdata", "test.sas7bdat")
   data <- haven::read_sas(path)
   max_32_bit <- 2147483647


### PR DESCRIPTION
# Description

Lets see if this fails in the Windows workflow 🤔 ⚗️ 

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
