### PR TITLE
feat: ✨ add pipeline warnings to conversion log template

### DIFF
--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -32,7 +32,7 @@ pipeline_warnings <- tar_meta(fields = warnings, complete_only = TRUE)
 
 if (nrow(pipeline_warnings) > 0) {
   cat("## Warnings\n\n")
-  cat("The pipeline produced the following warning(s).", 
+  cat("The pipeline produced the following warning(s).",
     "Please review them before proceeding:\n\n"
   )
   knitr::kable(pipeline_warnings)

--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -3,6 +3,9 @@ title: Conversion log
 format:
    pdf:
       toc: true
+execute:
+  echo: false
+  message: false
 ---
 
 ## About this log
@@ -23,8 +26,6 @@ library(targets)
 ```
 
 ```{r pipeline-warnings}
-#| echo: false
-#| message: false
 #| results: asis
 
 pipeline_warnings <- tar_meta(fields = warnings, complete_only = TRUE)
@@ -39,8 +40,6 @@ if (nrow(pipeline_warnings) > 0) {
 ```
 
 ```{r}
-#| echo: false
-#| message: false
 #| results: asis
 
 conversion_log <- tar_read(conversion_log)

--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -18,11 +18,30 @@ If you experience any problems or bugs with `fastreg`, please add an
 issue on GitHub by following this link:
 <https://github.com/dp-next/fastreg/issues/new>.
 
+```{r setup}
+library(targets)
+```
+
+```{r pipeline-warnings}
+#| echo: false
+#| message: false
+#| results: asis
+
+pipeline_warnings <- tar_meta(fields = warnings, complete_only = TRUE)
+
+if (nrow(pipeline_warnings) > 0) {
+  cat("## Warnings\n\n")
+  cat("The pipeline produced the following warning(s).", 
+    "Please review them before proceeding:\n\n"
+  )
+  knitr::kable(pipeline_warnings)
+}
+```
+
 ```{r}
 #| echo: false
 #| message: false
 #| results: asis
-library(targets)
 
 conversion_log <- tar_read(conversion_log)
 

--- a/inst/template-conversion-log.qmd
+++ b/inst/template-conversion-log.qmd
@@ -39,7 +39,7 @@ if (nrow(pipeline_warnings) > 0) {
 }
 ```
 
-```{r}
+```{r register-log}
 #| results: asis
 
 conversion_log <- tar_read(conversion_log)


### PR DESCRIPTION
# Description

As discussed on Discord, this adds warnings from the targets pipeline to the conversion log qmd. 

I also did a minor cleanup of the execute options and named the chunks.

Note: Not sure this should be a `feat` 🤔 

Needs a thorough review.

## Checklist

- [X] Ran `just run-all`
