### PR TITLE
fix: :bug: correct path part order so `workdata` or `rawdata` is before `<project-id>`

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -37,7 +37,7 @@ get_project_id <- function() {
 #' Looks in the [options()] for `fastreg.project_rawdata_dir` and
 #' `fastreg.project_workdata_dir` first, and if not found, constructs a path
 #' based on the project ID using `get_project_id()`. The constructed path is
-#' `E:/<project_id>/rawdata/` for raw data and `E:/<project_id>/workdata/` for n
+#' `E:/rawdata/<project_id>/` for raw data and `E:/workdata/<project_id>/` for n
 #' work data.
 #'
 #' @returns A path object.
@@ -58,7 +58,7 @@ get_project_rawdata_dir <- function() {
     )
   }
 
-  glue::glue("E:/{id}/rawdata/") |>
+  glue::glue("E:/rawdata/{id}/") |>
     fs::path()
 }
 
@@ -79,6 +79,6 @@ get_project_workdata_dir <- function() {
       )
     )
   }
-  glue::glue("E:/{id}/workdata/") |>
+  glue::glue("E:/workdata/{id}/") |>
     fs::path()
 }

--- a/R/read.R
+++ b/R/read.R
@@ -3,7 +3,7 @@
 #' This function uses the options `fastreg.project_rawdata_dir` and
 #' `fastreg.project_workdata_dir` when set in [options()] or will try to guess
 #' the path by using the project ID and the base directories
-#' `E:/<project-id>/rawdata/` and `E:/<project-id>/workdata/`. It only reads
+#' `E:/rawdata/<project-id>/` and `E:/workdata/<project-id>/`. It only reads
 #' Parquet datasets (those that are partitioned with the pattern `year=`). If
 #' this function doesn't work, use [read_parquet_dataset()] or
 #' [read_parquet_file()] instead.

--- a/man/read_register.Rd
+++ b/man/read_register.Rd
@@ -17,7 +17,7 @@ A DuckDB table.
 This function uses the options \code{fastreg.project_rawdata_dir} and
 \code{fastreg.project_workdata_dir} when set in \code{\link[=options]{options()}} or will try to guess
 the path by using the project ID and the base directories
-\verb{E:/<project-id>/rawdata/} and \verb{E:/<project-id>/workdata/}. It only reads
+\verb{E:/rawdata/<project-id>/} and \verb{E:/workdata/<project-id>/}. It only reads
 Parquet datasets (those that are partitioned with the pattern \verb{year=}). If
 this function doesn't work, use \code{\link[=read_parquet_dataset]{read_parquet_dataset()}} or
 \code{\link[=read_parquet_file]{read_parquet_file()}} instead.


### PR DESCRIPTION
# Description

@sara-schwartz found this issue, it should be `workdata|rawdata/<id>/`, not `<id>` first.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
